### PR TITLE
Bug fixes and improvements from the use of this in the Talky iOS app.

### DIFF
--- a/Classes/JAHWebRTC.h
+++ b/Classes/JAHWebRTC.h
@@ -11,6 +11,9 @@
 #import "RTCSessionDescription.h"
 #import "RTCICECandidate.h"
 #import "RTCMediaStream.h"
+#import "RTCTypes.h"
+
+@class RTCICEServer;
 
 @protocol JAHSignalDelegate;
 
@@ -18,12 +21,21 @@
 
 @property (nonatomic, weak) id <JAHSignalDelegate> signalDelegate;
 
+- (id)initAllowingVideo:(BOOL)allowVideo;
+
 - (void)addPeerConnectionForID:(NSString*)identifier;
 - (void)removePeerConnectionForID:(NSString*)identifier;
 
 - (void)createOfferForPeerWithID:(NSString*)peerID;
 - (void)setRemoteDescription:(RTCSessionDescription*)remoteSDP forPeerWithID:(NSString*)peerID receiver:(BOOL)isReceiver;
 - (void)addICECandidate:(RTCICECandidate*)candidate forPeerWithID:(NSString*)peerID;
+
+// Add a STUN or TURN server, adding a STUN server replaces the previous STUN server, adding a TURN server appends it to the list
+- (void)addICEServer:(RTCICEServer*)server;
+
+// The WebRTC stream captured locally that will be sent to peers, useful for displaying a preview of the local camera
+// in an RTCVideoRenderer and muting or blacking out th stream sent to peers
+@property (readonly, nonatomic) RTCMediaStream* localMediaStream;
 
 @end
 
@@ -33,8 +45,9 @@
 - (void)sendSDPOffer:(RTCSessionDescription*)offer forPeerWithID:(NSString*)peerID;
 - (void)sendSDPAnswer:(RTCSessionDescription*)answer forPeerWithID:(NSString*)peerID;
 - (void)sendICECandidate:(RTCICECandidate*)candidate forPeerWithID:(NSString*)peerID;
+- (void)ICEConnectionStateChanged:(RTCICEConnectionState)state forPeerWithID:(NSString*)peerID;
 
-- (void)addedStream:(RTCMediaStream*)stream;
-- (void)removedStream:(RTCMediaStream*)stream;
+- (void)addedStream:(RTCMediaStream*)stream forPeerWithID:(NSString*)peerID;
+- (void)removedStream:(RTCMediaStream*)stream forPeerWithID:(NSString*)peerID;
 
 @end

--- a/Classes/JAHWebRTC.m
+++ b/Classes/JAHWebRTC.m
@@ -15,6 +15,7 @@
 #import "RTCICEServer.h"
 #import "RTCPair.h"
 #import "RTCMediaConstraints.h"
+#import "RTCSessionDescription.h"
 #import "RTCSessionDescriptonDelegate.h"
 #import "RTCPeerConnectionDelegate.h"
 
@@ -24,10 +25,18 @@
 #import "RTCVideoTrack.h"
 
 @interface JAHWebRTC () <RTCSessionDescriptonDelegate, RTCPeerConnectionDelegate>
+
+@property (readwrite, nonatomic) RTCMediaStream* localMediaStream;
+
 @property (nonatomic, strong) RTCPeerConnectionFactory* peerFactory;
 @property (nonatomic, strong) NSMutableDictionary* peerConnections;
 @property (nonatomic, strong) NSMutableDictionary* peerToRoleMap;
 @property (nonatomic, strong) NSMutableDictionary* peerToICEMap;
+
+@property BOOL allowVideo;
+
+@property (nonatomic, strong) NSMutableArray* iceServers;
+
 @end
 
 NSString* const JAHPeerConnectionRoleInitiator = @"JAHPeerConnectionRoleInitiator";
@@ -35,31 +44,71 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
 
 @implementation JAHWebRTC
 
+- (id)initAllowingVideo:(BOOL)allowVideo {
+    self = [super init];
+	if (self) {
+        self.allowVideo = allowVideo;
+        [self commonSetup];
+	}
+	return self;
+}
+
 - (id)init {
 	self = [super init];
 	if (self) {
-        _peerFactory = [[RTCPeerConnectionFactory alloc] init];
-        _peerConnections = [NSMutableDictionary dictionary];
-        _peerToRoleMap = [NSMutableDictionary dictionary];
-        _peerToICEMap = [NSMutableDictionary dictionary];
-
-        [RTCPeerConnectionFactory initializeSSL];
+        self.allowVideo = YES;
+        [self commonSetup];
 	}
 	return self;
+}
+
+-(void)commonSetup {
+    _peerFactory = [[RTCPeerConnectionFactory alloc] init];
+    _peerConnections = [NSMutableDictionary dictionary];
+    _peerToRoleMap = [NSMutableDictionary dictionary];
+    _peerToICEMap = [NSMutableDictionary dictionary];
+    
+    self.iceServers = [NSMutableArray new];
+
+    RTCICEServer* defaultStunServer = [[RTCICEServer alloc] initWithURI:[NSURL URLWithString:@"stun:stun.l.google.com:19302"] username:@"" password:@""];
+    [self.iceServers addObject:defaultStunServer];
+
+    [RTCPeerConnectionFactory initializeSSL];
+    
+    [self initLocalStream];
+}
+
+- (void)addICEServer:(RTCICEServer*)server {
+    bool isStun = [server.URI.scheme isEqualToString:@"stun"];
+    
+    if (isStun) {
+        // Array of servers is always stored with stun server in first index, and we only want one,
+        // so if this is a stun server, replace it
+        [self.iceServers replaceObjectAtIndex:0 withObject:server];
+    }
+    else {
+        [self.iceServers addObject:server];
+    }
+}
+
+-(NSString*)identifierForPeer:(RTCPeerConnection*)peer {
+    NSArray* keys = [self.peerConnections allKeysForObject:peer];
+    return (keys.count == 0) ? nil : keys[0];
 }
 
 #pragma mark - Add/remove peerConnections
 
 - (void)addPeerConnectionForID:(NSString*)identifier {
 	RTCPeerConnection* peer = [self.peerFactory peerConnectionWithICEServers:[self iceServers] constraints:[self mediaConstraints] delegate:self];
-    [peer addStream:[self localStream] constraints:[self mediaConstraints]];
-
+    [peer addStream:self.localMediaStream constraints:[self mediaConstraints]];
 	[self.peerConnections setObject:peer forKey:identifier];
 }
 
 - (void)removePeerConnectionForID:(NSString*)identifier {
+    RTCPeerConnection* peer = self.peerConnections[identifier];
 	[self.peerConnections removeObjectForKey:identifier];
     [self.peerToRoleMap removeObjectForKey:identifier];
+    [peer close];
 }
 
 #pragma mark -
@@ -81,8 +130,6 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
 - (void)addICECandidate:(RTCICECandidate*)candidate forPeerWithID:(NSString*)peerID {
     RTCPeerConnection* peerConnection = [self.peerConnections objectForKey:peerID];
     if (peerConnection.iceGatheringState == RTCICEGatheringNew) {
-        // Queue ICE candidates until both the local and remote description are set
-        // When both are set, the ICE gathering state will be RTCICEGatheringGathering
         NSMutableArray* candidates = [self.peerToICEMap objectForKey:peerID];
         if (!candidates) {
             candidates = [NSMutableArray array];
@@ -101,8 +148,6 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
 }
 
 - (void)peerConnection:(RTCPeerConnection*)peerConnection didSetSessionDescriptionWithError:(NSError*)error {
-    [self logPeerState:peerConnection];
-
     if (peerConnection.iceGatheringState == RTCICEGatheringGathering) {
         NSArray* keys = [self.peerConnections allKeysForObject:peerConnection];
         if ([keys count] > 0) {
@@ -132,11 +177,7 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
     }
 }
 
-#pragma mark - RTCPeerConnectionDelegate methods
-
-- (void)peerConnectionOnError:(RTCPeerConnection *)peerConnection {
-    NSLog(@"peerConnectionOnError:");
-}
+#pragma mark - String utilities
 
 - (NSString*)stringForSignalingState:(RTCSignalingState)state {
     switch (state) {
@@ -156,26 +197,6 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
             return @"Other state";
             break;
     }
-}
-
-- (void)peerConnection:(RTCPeerConnection *)peerConnection signalingStateChanged:(RTCSignalingState)stateChanged {
-    NSLog(@"peerConnection:signalingStateChanged: state-> %@", [self stringForSignalingState:stateChanged]);
-}
-
-- (void)peerConnection:(RTCPeerConnection *)peerConnection addedStream:(RTCMediaStream *)stream {
-    NSLog(@"peerConnection:addedStream:");
-
-    [self.signalDelegate addedStream:stream];
-}
-
-- (void)peerConnection:(RTCPeerConnection *)peerConnection removedStream:(RTCMediaStream *)stream {
-    NSLog(@"peerConnection:removedStream:");
-
-    [self.signalDelegate removedStream:stream];
-}
-
-- (void)peerConnectionOnRenegotiationNeeded:(RTCPeerConnection *)peerConnection {
-    NSLog(@"peerConnectionOnRenegotiationNeeded:");
 }
 
 - (NSString*)stringForConnectionState:(RTCICEConnectionState)state {
@@ -207,10 +228,6 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
     }
 }
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection iceConnectionChanged:(RTCICEConnectionState)newState {
-    NSLog(@"peerConnection:iceConnectionChanged: state-> %@", [self stringForConnectionState:newState]);
-}
-
 - (NSString*)stringForGatheringState:(RTCICEGatheringState)state {
     switch (state) {
         case RTCICEGatheringNew:
@@ -228,47 +245,87 @@ NSString* const JAHPeerConnectionRoleReceiver = @"JAHPeerConnectionRoleReceiver"
     }
 }
 
+#pragma mark - RTCPeerConnectionDelegate methods
+
+// Note: all these delegate calls come back on a random background thread inside WebRTC,
+// so all are bridged across to the main thread
+
+- (void)peerConnectionOnError:(RTCPeerConnection *)peerConnection {
+    dispatch_async(dispatch_get_main_queue(), ^{
+    });
+}
+
+- (void)peerConnection:(RTCPeerConnection *)peerConnection signalingStateChanged:(RTCSignalingState)stateChanged {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // I'm seeing this, but not sure what to do with it yet
+    });
+}
+
+- (void)peerConnection:(RTCPeerConnection *)peerConnection addedStream:(RTCMediaStream *)stream {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.signalDelegate addedStream:stream forPeerWithID:[self identifierForPeer:peerConnection]];
+    });
+}
+
+- (void)peerConnection:(RTCPeerConnection *)peerConnection removedStream:(RTCMediaStream *)stream {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.signalDelegate removedStream:stream forPeerWithID:[self identifierForPeer:peerConnection]];
+    });
+}
+
+- (void)peerConnectionOnRenegotiationNeeded:(RTCPeerConnection *)peerConnection {
+    dispatch_async(dispatch_get_main_queue(), ^{
+    //    [self.peerConnection createOfferWithDelegate:self constraints:[self mediaConstraints]];
+    // Is this delegate called when creating a PC that is going to *receive* an offer and return an answer?
+    });
+}
+
+- (void)peerConnection:(RTCPeerConnection *)peerConnection iceConnectionChanged:(RTCICEConnectionState)newState {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.signalDelegate ICEConnectionStateChanged:newState forPeerWithID:[self identifierForPeer:peerConnection]];
+    });
+}
+
 - (void)peerConnection:(RTCPeerConnection *)peerConnection iceGatheringChanged:(RTCICEGatheringState)newState {
-    NSLog(@"peerConnection:iceGatheringChanged: state-> %@", [self stringForGatheringState:newState]);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // I'm seeing this, but not sure what to do with it yet
+    });
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection gotICECandidate:(RTCICECandidate *)candidate {
-    NSArray* keys = [self.peerConnections allKeysForObject:peerConnection];
-    if ([keys count] > 0) {
-        [self.signalDelegate sendICECandidate:candidate forPeerWithID:keys[0]];
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+
+        NSArray* keys = [self.peerConnections allKeysForObject:peerConnection];
+        if ([keys count] > 0) {
+            [self.signalDelegate sendICECandidate:candidate forPeerWithID:keys[0]];
+        }
+    });
 }
 
 #pragma mark -
 
-- (NSArray*)iceServers {
-    RTCICEServer* stunServer = [[RTCICEServer alloc] initWithURI:[NSURL URLWithString:@"stun:stun.l.google.com:19302"] username:@"" password:@""];
-    return @[stunServer];
-}
-
 - (RTCMediaConstraints*)mediaConstraints {
     RTCPair* audioConstraint = [[RTCPair alloc] initWithKey:@"OfferToReceiveAudio" value:@"true"];
-    RTCPair* videoConstraint = [[RTCPair alloc] initWithKey:@"OfferToReceiveVideo" value:@"true"];
+    RTCPair* videoConstraint = [[RTCPair alloc] initWithKey:@"OfferToReceiveVideo" value:self.allowVideo ? @"true" : @"false"];
     RTCPair* sctpConstraint = [[RTCPair alloc] initWithKey:@"internalSctpDataChannels" value:@"true"];
     RTCPair* dtlsConstraint = [[RTCPair alloc] initWithKey:@"DtlsSrtpKeyAgreement" value:@"true"];
 
     return [[RTCMediaConstraints alloc] initWithMandatoryConstraints:@[audioConstraint, videoConstraint] optionalConstraints:@[sctpConstraint, dtlsConstraint]];
 }
 
-- (RTCMediaStream*)localStream {
-    RTCMediaStream* stream = [self.peerFactory mediaStreamWithLabel:@"localStream"];
+- (void)initLocalStream {
+    self.localMediaStream = [self.peerFactory mediaStreamWithLabel:[[NSUUID UUID] UUIDString]];
 
-    RTCAudioTrack* audioTrack = [self.peerFactory audioTrackWithID:@"localAudio"];
-    [stream addAudioTrack:audioTrack];
+    RTCAudioTrack* audioTrack = [self.peerFactory audioTrackWithID:[[NSUUID UUID] UUIDString]];
+    [self.localMediaStream addAudioTrack:audioTrack];
 
-    //    AVCaptureDevice* device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
-    AVCaptureDevice* device = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo][1];
-    RTCVideoCapturer* capturer = [RTCVideoCapturer capturerWithDeviceName:[device localizedName]];
-    RTCVideoSource *videoSource = [self.peerFactory videoSourceWithCapturer:capturer constraints:nil];
-    RTCVideoTrack* videoTrack = [self.peerFactory videoTrackWithID:@"localVideo" source:videoSource];
-    [stream addVideoTrack:videoTrack];
-
-    return stream;
+    if(self.allowVideo) {
+        AVCaptureDevice* device = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo][1];
+        RTCVideoCapturer* capturer = [RTCVideoCapturer capturerWithDeviceName:[device localizedName]];
+        RTCVideoSource *videoSource = [self.peerFactory videoSourceWithCapturer:capturer constraints:nil];
+        RTCVideoTrack* videoTrack = [self.peerFactory videoTrackWithID:[[NSUUID UUID] UUIDString] source:videoSource];
+        [self.localMediaStream addVideoTrack:videoTrack];
+    }
 }
 
 @end


### PR DESCRIPTION
Add support for audio only use.
Add support for setting STUN and TURN servers.
Broadcast a single local stream to all peers, and provide a public accessor.
Add state change method to signal delegate.
Add peer identifier to stream methods in signal delegate.
Make sure that callbacks from within WebRTC are all bridged to main thread.
